### PR TITLE
bin/makefile.lint: add go mod tidy

### DIFF
--- a/bin/Makefile.base
+++ b/bin/Makefile.base
@@ -19,6 +19,7 @@ test_fmt:
 test_lint: $(GOPATH)/bin/golint
 	@echo Checking linting of files
 	out=`$< ./... | $(lint-filter)`; echo "$$out"; [ -z "$$out" ]
+	go mod tidy && [ -z "`git status --porcelain`" ]
 $(GOPATH)/bin/golint:
 	go get golang.org/x/lint/golint
 


### PR DESCRIPTION
add a lint check that `go mod tidy` was ran.