### PR TITLE
Remove git status --porcelain

### DIFF
--- a/bin/Makefile.base
+++ b/bin/Makefile.base
@@ -19,7 +19,7 @@ test_fmt:
 test_lint: $(GOPATH)/bin/golint
 	@echo Checking linting of files
 	out=`$< ./... | $(lint-filter)`; echo "$$out"; [ -z "$$out" ]
-	go mod tidy && [ -z "`git status --porcelain`" ]
+	go mod tidy
 $(GOPATH)/bin/golint:
 	go get golang.org/x/lint/golint
 


### PR DESCRIPTION
As the 'Coding' repo is included in the repo for the Makefile,
git status --porcelain will fail.