### PR TITLE
Add test_imports rule to call goimports

### DIFF
--- a/bin/Makefile.base
+++ b/bin/Makefile.base
@@ -18,7 +18,7 @@ test_fmt:
 .PHONY: test_imports
 test_imports:
 	@echo Checking correct formatting and import lines of files
-	out=`goimports -l -s .`; echo "$$out"; [ -z "$$out" ]
+	out=`goimports -l .`; echo "$$out"; [ -z "$$out" ]
 	go vet ./...
 
 .PHONY: test_lint

--- a/bin/Makefile.base
+++ b/bin/Makefile.base
@@ -15,6 +15,12 @@ test_fmt:
 	out=`gofmt -l -s .`; echo "$$out"; [ -z "$$out" ]
 	go vet ./...
 
+.PHONY: test_imports
+test_imports:
+	@echo Checking correct formatting and import lines of files
+	out=`goimports -l -s .`; echo "$$out"; [ -z "$$out" ]
+	go vet ./...
+
 .PHONY: test_lint
 test_lint: $(GOPATH)/bin/golint
 	@echo Checking linting of files

--- a/bin/Makefile.base
+++ b/bin/Makefile.base
@@ -16,10 +16,11 @@ test_fmt:
 	go vet ./...
 
 .PHONY: test_imports
-test_imports:
+test_imports: $(GOPATH)/bin/goimports
 	@echo Checking correct formatting and import lines of files
 	out=`goimports -l .`; echo "$$out"; [ -z "$$out" ]
-	go vet ./...
+$(GOPATH)/bin/goimports:
+	GO111MODULE=off go get golang.org/x/tools/imports
 
 .PHONY: test_lint
 test_lint: $(GOPATH)/bin/golint


### PR DESCRIPTION
Related to #9, only adds a new rule to call `goimports`