### PR TITLE
Fix goimports url

### DIFF
--- a/bin/Makefile.base
+++ b/bin/Makefile.base
@@ -18,7 +18,7 @@ test_fmt:
 .PHONY: test_imports
 test_imports: $(GOPATH)/bin/goimports
 	@echo Checking correct formatting and import lines of files
-	out=`goimports -l .`; echo "$$out"; [ -z "$$out" ]
+	out=`$< -l .`; echo "$$out"; [ -z "$$out" ]
 $(GOPATH)/bin/goimports:
 	GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 
@@ -32,7 +32,7 @@ $(GOPATH)/bin/golint:
 
 .PHONY: test_goveralls
 test_goveralls: profile.cov $(GOPATH)/bin/goveralls
-	goveralls -coverprofile=$< -service=travis-ci
+	$(word 2,$^) -coverprofile=$< -service=travis-ci
 .INTERMEDIATE: profile.cov
 profile.cov:
 	$(CODING)/bin/coveralls.sh

--- a/bin/Makefile.base
+++ b/bin/Makefile.base
@@ -20,7 +20,7 @@ test_imports: $(GOPATH)/bin/goimports
 	@echo Checking correct formatting and import lines of files
 	out=`goimports -l .`; echo "$$out"; [ -z "$$out" ]
 $(GOPATH)/bin/goimports:
-	GO111MODULE=off go get golang.org/x/tools/imports
+	GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 
 .PHONY: test_lint
 test_lint: $(GOPATH)/bin/golint


### PR DESCRIPTION
In #10, `goimports` has been introduced in target `test_imports`. The url to get the CLI is wrong, this PR is fixing it.
While at it, I'm also using the full path for the fetched binary: not everyone added `$GOPATH/bin` to `PATH`.